### PR TITLE
Client: add [getter, setter] for `auth`, `auth_bearer`, `params`, `headers`, `proxy`, `timeout`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "rquest"
-version = "0.31.8"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ec45993a20ed6cfdfd5545352ff8e4611f6ced82a26063d21a23730db13d462"
+checksum = "21a83ebe45a39634fc77f8ceb412b7ea94bdaea81e3aa35277cdf79d078d7488"
 dependencies = [
  "antidote",
  "async-compression",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,9 +207,9 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
 dependencies = [
  "jobserver",
  "libc",
@@ -517,7 +517,7 @@ dependencies = [
  "markup5ever",
  "nom",
  "tendril",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "unicode-width",
 ]
 
@@ -1274,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
 ]
@@ -1312,9 +1312,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rh2"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5534f49710d4a7255704ffdf52208099f99c2c52ea7ea16eb890bf6dd551f097"
+checksum = "6825fa5e9bd37b036324b87e104ece799eebb3494e7c59bbac8458f1ae7c1b69"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1389,9 +1389,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
 name = "ryu"
@@ -1407,18 +1407,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1598,11 +1598,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
+checksum = "93605438cbd668185516ab499d589afb7ee1859ea3d5fc8f6b0755e1c7443767"
 dependencies = [
- "thiserror-impl 2.0.6",
+ "thiserror-impl 2.0.7",
 ]
 
 [[package]]
@@ -1618,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
+checksum = "e1d8749b4531af2117677a5fcd12b1348a3fe2b81e36e61ffeac5c4aa3273e36"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,19 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "getrandom",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +357,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "foreign-types"
@@ -1105,10 +1098,10 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 name = "primp"
 version = "0.8.3"
 dependencies = [
- "ahash",
  "anyhow",
  "bytes",
  "encoding_rs",
+ "foldhash",
  "html2text",
  "indexmap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rquest = { version = "0.32", features = [
     "zstd",
 ] }
 encoding_rs = { version = "0.8" }
-ahash = "0.8"
+foldhash = "0.1.3"
 indexmap = { version = "2", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 html2text = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ pyo3 = { version = "0.23", features = ["extension-module", "abi3-py38", "indexma
 anyhow = "1"
 log = "0.4"
 pyo3-log = "0.12"
-rquest = { version = "0.31", features = [
+rquest = { version = "0.32", features = [
     "cookies",
     "multipart",
     "json",

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ class Client:
         max_redirects (int, optional): Maximum redirects to follow. Default 20. Applies if `follow_redirects` is True.
         verify (bool, optional): Verify SSL certificates. Default is True.
         ca_cert_file (str, optional): Path to CA certificate store. Default is None.
-        http1 (bool, optional): Use only HTTP/1.1. Default is None.
-        http2 (bool, optional): Use only HTTP/2. Default is None.
+        https_only`: Restrict the Client to be used with HTTPS only requests. Default is `false`.
+        http2_only`: If true - use only HTTP/2; if false - use only HTTP/1. Default is `false`.
 
     """
 ```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ class Client:
                 "chrome_123","chrome_124","chrome_126","chrome_127","chrome_128","chrome_129","chrome_130",
                 "chrome_131"
             Safari: "safari_ios_16.5","safari_ios_17.2","safari_ios_17.4.1","safari_15.3","safari_15.5","safari_15.6.1",
-                "safari_16","safari_16.5","safari_17.0","safari_17.2.1","safari_17.4.1","safari_17.5","safari_18",
+                "safari_16","safari_16.5","safari_17.0","safari_17.2.1","safari_17.4.1","safari_17.5","safari_18","safari_18.2",
                 "safari_ipad_18"
             OkHttp: "okhttp_3.9","okhttp_3.11","okhttp_3.13","okhttp_3.14","okhttp_4.9","okhttp_4.10","okhttp_5"
             Edge: "edge_101","edge_122","edge_127"
@@ -146,13 +146,13 @@ resp.url
 
 #### Devices
 
-- Chrome: `Chrome100`，`Chrome101`，`Chrome104`，`Chrome105`，`Chrome106`，`Chrome107`，`Chrome108`，`Chrome109`，`Chrome114`，`Chrome116`，`Chrome117`，`Chrome118`，`Chrome119`，`Chrome120`，`Chrome123`，`Chrome124`，`Chrome126`，`Chrome127`，`Chrome128`，`Chrome129`，`Chrome130`，`Chrome131`
+- Chrome: `chrome_100`，`chrome_101`，`chrome_104`，`chrome_105`，`chrome_106`，`chrome_107`，`chrome_108`，`chrome_109`，`chrome_114`，`chrome_116`，`chrome_117`，`chrome_118`，`chrome_119`，`chrome_120`，`chrome_123`，`chrome_124`，`chrome_126`，`chrome_127`，`chrome_128`，`chrome_129`，`chrome_130`，`chrome_131`
 
-- Edge: `Edge101`，`Edge122`，`Edge127`
+- Edge: `edge_101`，`edge_122`，`edge_127`
 
-- Safari: `SafariIos17_2`，`SafariIos17_4_1`，`SafariIos16_5`，`Safari15_3`，`Safari15_5`，`Safari15_6_1`，`Safari16`，`Safari16_5`，`Safari17_0`，`Safari17_2_1`，`Safari17_4_1`，`Safari17_5`，`Safari18`，`SafariIPad18`
+- Safari: `safari_ios_17.2`，`safari_ios_17.4.1`，`safari_ios_16.5`，`safari_15.3`，`safari_15.5`，`safari_15.6.1`，`safari_16`，`safari_16.5`，`safari_17.0`，`safari_17.2.1`，`safari_17.4.1`，`safari_17.5`，`safari_18`，`safari_18.2`, `safari_ipad_18`
 
-- OkHttp: `OkHttp3_9`，`OkHttp3_11`，`OkHttp3_13`，`OkHttp3_14`，`OkHttp4_9`，`OkHttp4_10`，`OkHttp5`
+- OkHttp: `okhttp_3.9`，`okhttp_3.11`，`okhttp_3.13`，`okhttp_3.14`，`okhttp_4.9`，`okhttp_4.10`，`okhttp_5`
 
 #### Examples
 

--- a/src/impersonate.rs
+++ b/src/impersonate.rs
@@ -7,7 +7,7 @@ use rquest::{
     header::{self, HeaderMap, HeaderName, HeaderValue, ACCEPT},
     tls::{
         cert_compression::CertCompressionAlgorithm, Http2Settings, ImpersonateSettings,
-        TlsSettings, Version,
+        TlsSettings, TlsVersion,
     },
     HttpVersionPref,
     PseudoOrder::{self, *},
@@ -161,8 +161,8 @@ pub fn get_chaos_impersonate_settings() -> Result<ImpersonateSettings, Error> {
         .curves(Cow::Owned(shuffle_list(CURVES)))
         .sigalgs_list(Cow::Owned(shuffle_list(SIGALGS_LIST).join(":")))
         .cipher_list(Cow::Owned(shuffle_list(CIPHER_LIST).join(":")))
-        .min_tls_version(Version::TLS_1_2)
-        .max_tls_version(Version::TLS_1_3)
+        .min_tls_version(TlsVersion::TLS_1_2)
+        .max_tls_version(TlsVersion::TLS_1_3)
         .permute_extensions(true)
         .pre_shared_key(true)
         .enable_ech_grease(true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@ use std::str::FromStr;
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 
-use ahash::RandomState;
 use anyhow::{Error, Result};
 use bytes::Bytes;
+use foldhash::fast::RandomState;
 use indexmap::IndexMap;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,10 +127,6 @@ impl Client {
         https_only: Option<bool>,
         http2_only: Option<bool>,
     ) -> Result<Self> {
-        if auth.is_some() && auth_bearer.is_some() {
-            return Err(PyValueError::new_err("Cannot provide both auth and auth_bearer").into());
-        }
-
         // Client builder
         let mut client_builder = rquest::Client::builder();
 
@@ -303,9 +299,6 @@ impl Client {
         let json_value: Option<Value> = json.map(|json| depythonize(&json)).transpose()?;
         let auth = auth.or_else(|| self.auth.clone());
         let auth_bearer = auth_bearer.or_else(|| self.auth_bearer.clone());
-        if auth.is_some() && auth_bearer.is_some() {
-            return Err(PyValueError::new_err("Cannot provide both auth and auth_bearer").into());
-        }
         let is_post_put_patch = method == "POST" || method == "PUT" || method == "PATCH";
 
         let future = async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,8 @@ impl Client {
     /// * `max_redirects` - The maximum number of redirects to follow. Default is 20. Applies if `follow_redirects` is `true`.
     /// * `verify` - An optional boolean indicating whether to verify SSL certificates. Default is `true`.
     /// * `ca_cert_file` - Path to CA certificate store. Default is None.
-    /// * `http1` - An optional boolean indicating whether to use only HTTP/1.1. Default is `false`.
-    /// * `http2` - An optional boolean indicating whether to use only HTTP/2. Default is `false`.
+    /// * `https_only` - Restrict the Client to be used with HTTPS only requests. Default is `false`.
+    /// * `http2_only` - If true - use only HTTP/2, if false - use only HTTP/1. Default is `false`.
     ///
     /// # Example
     ///
@@ -94,14 +94,14 @@ impl Client {
     ///     max_redirects=1,
     ///     verify=True,
     ///     ca_cert_file="/cert/cacert.pem",
-    ///     http1=True,
-    ///     http2=False,
+    ///     https_only=True,
+    ///     http2_only=True,
     /// )
     /// ```
     #[new]
     #[pyo3(signature = (auth=None, auth_bearer=None, params=None, headers=None, cookies=None,
-        cookie_store=None, referer=None, proxy=None, timeout=None, impersonate=None, follow_redirects=None,
-        max_redirects=None, verify=None, ca_cert_file=None, http1=None, http2=None))]
+        cookie_store=true, referer=true, proxy=None, timeout=None, impersonate=None, follow_redirects=true,
+        max_redirects=20, verify=true, ca_cert_file=None, https_only=false, http2_only=false))]
     fn new(
         auth: Option<(String, Option<String>)>,
         auth_bearer: Option<String>,
@@ -117,8 +117,8 @@ impl Client {
         max_redirects: Option<usize>,
         verify: Option<bool>,
         ca_cert_file: Option<String>,
-        http1: Option<bool>,
-        http2: Option<bool>,
+        https_only: Option<bool>,
+        http2_only: Option<bool>,
     ) -> Result<Self> {
         if auth.is_some() && auth_bearer.is_some() {
             return Err(PyValueError::new_err("Cannot provide both auth and auth_bearer").into());
@@ -200,14 +200,14 @@ impl Client {
             client_builder = client_builder.danger_accept_invalid_certs(true);
         }
 
-        // Http version: http1 || http2
-        match (http1, http2) {
-            (Some(true), Some(true)) => {
-                return Err(PyValueError::new_err("Both http1 and http2 cannot be true").into())
-            }
-            (Some(true), _) => client_builder = client_builder.http1_only(),
-            (_, Some(true)) => client_builder = client_builder.http2_only(),
-            _ => (),
+        // Https_only
+        if let Some(true) = https_only {
+            client_builder = client_builder.https_only(true);
+        }
+
+        // Http2_only
+        if let Some(true) = http2_only {
+            client_builder = client_builder.http2_only();
         }
 
         let client = Arc::new(client_builder.build()?);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::str::FromStr;
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
@@ -6,7 +7,6 @@ use anyhow::{Error, Result};
 use bytes::Bytes;
 use foldhash::fast::RandomState;
 use indexmap::IndexMap;
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pythonize::depythonize;
@@ -50,8 +50,12 @@ pub struct Client {
     auth_bearer: Option<String>,
     #[pyo3(get, set)]
     params: Option<IndexMap<String, String, RandomState>>,
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     cookies: Option<IndexMap<String, String, RandomState>>,
+    #[pyo3(get, set)]
+    proxy: Option<String>,
+    #[pyo3(get, set)]
+    timeout: Option<f64>,
 }
 
 #[pymethods]
@@ -119,7 +123,7 @@ impl Client {
         referer: Option<bool>,
         proxy: Option<String>,
         timeout: Option<f64>,
-        impersonate: Option<&str>,
+        impersonate: Option<String>,
         follow_redirects: Option<bool>,
         max_redirects: Option<usize>,
         verify: Option<bool>,
@@ -131,7 +135,7 @@ impl Client {
         let mut client_builder = rquest::Client::builder();
 
         // Impersonate
-        match impersonate {
+        match impersonate.as_deref() {
             Some("chaos") => {
                 let chaos_impersonate_settings = get_chaos_impersonate_settings()?;
                 client_builder = client_builder.impersonate_settings(chaos_impersonate_settings);
@@ -165,9 +169,9 @@ impl Client {
         }
 
         // Proxy
-        if let Some(proxy_url) = proxy.or_else(|| std::env::var("PRIMP_PROXY").ok()) {
-            let proxy = rquest::Proxy::all(proxy_url)?;
-            client_builder = client_builder.proxy(proxy);
+        let proxy = proxy.or_else(|| std::env::var("PRIMP_PROXY").ok());
+        if let Some(proxy) = &proxy {
+            client_builder = client_builder.proxy(rquest::Proxy::all(proxy)?);
         }
 
         // Timeout
@@ -176,15 +180,14 @@ impl Client {
         }
 
         // Redirects
-        let max_redirects = max_redirects.unwrap_or(20);
         if follow_redirects.unwrap_or(true) {
-            client_builder = client_builder.redirect(Policy::limited(max_redirects));
+            client_builder = client_builder.redirect(Policy::limited(max_redirects.unwrap_or(20)));
         } else {
             client_builder = client_builder.redirect(Policy::none());
         }
 
         // Ca_cert_file. BEFORE!!! verify (fn load_ca_certs() reads env var PRIMP_CA_BUNDLE)
-        if let Some(ca_bundle_path) = ca_cert_file {
+        if let Some(ca_bundle_path) = &ca_cert_file {
             std::env::set_var("PRIMP_CA_BUNDLE", ca_bundle_path);
         }
 
@@ -213,6 +216,8 @@ impl Client {
             auth_bearer,
             params,
             cookies,
+            proxy,
+            timeout,
         })
     }
 
@@ -237,6 +242,31 @@ impl Client {
         }
         Ok(())
     }
+
+    #[getter]
+    pub fn get_proxy(&self) -> Result<Option<String>> {
+        Ok(self.proxy.to_owned())
+    }
+
+    #[setter]
+    pub fn set_proxy(&mut self, proxy: String) -> Result<()> {
+        let mut client = self.client.lock().unwrap();
+        let rproxy = rquest::Proxy::all(proxy.clone())?;
+        client.set_proxies(Cow::Owned(vec![rproxy]));
+        self.proxy = Some(proxy);
+        Ok(())
+    }
+
+    //#[setter]
+    //pub fn set_cookies(
+    //    &self,
+    //    new_cookies: Option<IndexMap<String, String, RandomState>>,
+    //) -> Result<()> {
+    //    let mut client = self.client.lock().unwrap();
+    //    if let Some(new_cookies) = new_cookies {
+    //        client.set_cookies(cookies, url)
+    //    }
+    //}
 
     /// Constructs an HTTP request with the given method, URL, and optionally sets a timeout, headers, and query parameters.
     /// Sends the request and returns a `Response` object containing the server's response.
@@ -284,15 +314,15 @@ impl Client {
         let client = Arc::clone(&self.client);
         // Method
         let method = match method {
-            "GET" => Ok(Method::GET),
-            "POST" => Ok(Method::POST),
-            "HEAD" => Ok(Method::HEAD),
-            "OPTIONS" => Ok(Method::OPTIONS),
-            "PUT" => Ok(Method::PUT),
-            "PATCH" => Ok(Method::PATCH),
-            "DELETE" => Ok(Method::DELETE),
-            _ => Err(PyValueError::new_err("Unrecognized HTTP method")),
-        }?;
+            "GET" => Method::GET,
+            "POST" => Method::POST,
+            "HEAD" => Method::HEAD,
+            "OPTIONS" => Method::OPTIONS,
+            "PUT" => Method::PUT,
+            "PATCH" => Method::PATCH,
+            "DELETE" => Method::DELETE,
+            _ => panic!("Unrecognized HTTP method"),
+        };
         let params = params.or_else(|| self.params.clone());
         let cookies = cookies.or_else(|| self.cookies.clone());
         let data_value: Option<Value> = data.map(|data| depythonize(&data)).transpose()?;
@@ -300,6 +330,7 @@ impl Client {
         let auth = auth.or_else(|| self.auth.clone());
         let auth_bearer = auth_bearer.or_else(|| self.auth_bearer.clone());
         let is_post_put_patch = method == "POST" || method == "PUT" || method == "PATCH";
+        let timeout: Option<f64> = timeout.or_else(|| self.timeout);
 
         let future = async move {
             // Create request builder
@@ -643,7 +674,7 @@ fn request(
     auth: Option<(String, Option<String>)>,
     auth_bearer: Option<String>,
     timeout: Option<f64>,
-    impersonate: Option<&str>,
+    impersonate: Option<String>,
     verify: Option<bool>,
     ca_cert_file: Option<String>,
 ) -> Result<Response> {
@@ -694,7 +725,7 @@ fn get(
     auth: Option<(String, Option<String>)>,
     auth_bearer: Option<String>,
     timeout: Option<f64>,
-    impersonate: Option<&str>,
+    impersonate: Option<String>,
     verify: Option<bool>,
     ca_cert_file: Option<String>,
 ) -> Result<Response> {
@@ -740,7 +771,7 @@ fn head(
     auth: Option<(String, Option<String>)>,
     auth_bearer: Option<String>,
     timeout: Option<f64>,
-    impersonate: Option<&str>,
+    impersonate: Option<String>,
     verify: Option<bool>,
     ca_cert_file: Option<String>,
 ) -> Result<Response> {
@@ -786,7 +817,7 @@ fn options(
     auth: Option<(String, Option<String>)>,
     auth_bearer: Option<String>,
     timeout: Option<f64>,
-    impersonate: Option<&str>,
+    impersonate: Option<String>,
     verify: Option<bool>,
     ca_cert_file: Option<String>,
 ) -> Result<Response> {
@@ -832,7 +863,7 @@ fn delete(
     auth: Option<(String, Option<String>)>,
     auth_bearer: Option<String>,
     timeout: Option<f64>,
-    impersonate: Option<&str>,
+    impersonate: Option<String>,
     verify: Option<bool>,
     ca_cert_file: Option<String>,
 ) -> Result<Response> {
@@ -883,7 +914,7 @@ fn post(
     auth: Option<(String, Option<String>)>,
     auth_bearer: Option<String>,
     timeout: Option<f64>,
-    impersonate: Option<&str>,
+    impersonate: Option<String>,
     verify: Option<bool>,
     ca_cert_file: Option<String>,
 ) -> Result<Response> {
@@ -938,7 +969,7 @@ fn put(
     auth: Option<(String, Option<String>)>,
     auth_bearer: Option<String>,
     timeout: Option<f64>,
-    impersonate: Option<&str>,
+    impersonate: Option<String>,
     verify: Option<bool>,
     ca_cert_file: Option<String>,
 ) -> Result<Response> {
@@ -993,7 +1024,7 @@ fn patch(
     auth: Option<(String, Option<String>)>,
     auth_bearer: Option<String>,
     timeout: Option<f64>,
-    impersonate: Option<&str>,
+    impersonate: Option<String>,
     verify: Option<bool>,
     ca_cert_file: Option<String>,
 ) -> Result<Response> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use std::sync::{Arc, LazyLock};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 
 use ahash::RandomState;
@@ -11,7 +11,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pythonize::depythonize;
 use rquest::{
-    header::{HeaderMap, HeaderName, HeaderValue, COOKIE},
+    header::{HeaderValue, COOKIE},
     multipart,
     redirect::Policy,
     tls::Impersonate,
@@ -25,6 +25,9 @@ use impersonate::{get_chaos_impersonate_settings, get_random_element, IMPERSONAT
 
 mod response;
 use response::Response;
+
+mod traits;
+use traits::HeadersTraits;
 
 mod utils;
 use utils::load_ca_certs;
@@ -40,10 +43,14 @@ static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
 #[pyclass]
 /// HTTP client that can impersonate web browsers.
 pub struct Client {
-    client: Arc<rquest::Client>,
+    client: Arc<Mutex<rquest::Client>>,
+    #[pyo3(get, set)]
     auth: Option<(String, Option<String>)>,
+    #[pyo3(get, set)]
     auth_bearer: Option<String>,
+    #[pyo3(get, set)]
     params: Option<IndexMap<String, String, RandomState>>,
+    #[pyo3(get)]
     cookies: Option<IndexMap<String, String, RandomState>>,
 }
 
@@ -148,15 +155,7 @@ impl Client {
 
         // Headers
         if let Some(headers) = headers {
-            let headers_new = headers
-                .iter()
-                .filter_map(|(k, v)| {
-                    HeaderName::from_bytes(k.as_bytes())
-                        .ok()
-                        .and_then(|name| HeaderValue::from_str(v).ok().map(|value| (name, value)))
-                })
-                .collect::<HeaderMap>();
-            client_builder = client_builder.default_headers(headers_new);
+            client_builder = client_builder.default_headers(headers.to_headermap());
         }
 
         // Cookie_store
@@ -210,7 +209,7 @@ impl Client {
             client_builder = client_builder.http2_only();
         }
 
-        let client = Arc::new(client_builder.build()?);
+        let client = Arc::new(Mutex::new(client_builder.build()?));
 
         Ok(Client {
             client,
@@ -219,6 +218,28 @@ impl Client {
             params,
             cookies,
         })
+    }
+
+    #[getter]
+    pub fn get_headers(&self) -> Result<IndexMap<String, String, RandomState>> {
+        let headers = self.client.lock().unwrap().headers_mut().to_indexmap();
+        Ok(headers)
+    }
+
+    #[setter]
+    pub fn set_headers(
+        &self,
+        new_headers: Option<IndexMap<String, String, RandomState>>,
+    ) -> Result<()> {
+        let mut client = self.client.lock().unwrap();
+        let headers = client.headers_mut();
+        headers.clear();
+        if let Some(new_headers) = new_headers {
+            for (k, v) in new_headers {
+                headers.insert_key_value(k, v)?
+            }
+        }
+        Ok(())
     }
 
     /// Constructs an HTTP request with the given method, URL, and optionally sets a timeout, headers, and query parameters.
@@ -289,7 +310,7 @@ impl Client {
 
         let future = async move {
             // Create request builder
-            let mut request_builder = client.request(method, url);
+            let mut request_builder = client.lock().unwrap().request(method, url);
 
             // Params
             if let Some(params) = params {
@@ -298,15 +319,7 @@ impl Client {
 
             // Headers
             if let Some(headers) = headers {
-                let headers_new = headers
-                    .iter()
-                    .filter_map(|(k, v)| {
-                        HeaderName::from_bytes(k.as_bytes()).ok().and_then(|name| {
-                            HeaderValue::from_str(v).ok().map(|value| (name, value))
-                        })
-                    })
-                    .collect::<HeaderMap>();
-                request_builder = request_builder.headers(headers_new);
+                request_builder = request_builder.headers(headers.to_headermap());
             }
 
             // Cookies
@@ -366,11 +379,7 @@ impl Client {
                 .cookies()
                 .map(|cookie| (cookie.name().to_string(), cookie.value().to_string()))
                 .collect();
-            let headers: IndexMap<String, String, RandomState> = resp
-                .headers()
-                .iter()
-                .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
-                .collect();
+            let headers: IndexMap<String, String, RandomState> = resp.headers().to_indexmap();
             let status_code = resp.status().as_u16();
             let url = resp.url().to_string();
             let buf = resp.bytes().await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ impl Client {
         match impersonate {
             Some("chaos") => {
                 let chaos_impersonate_settings = get_chaos_impersonate_settings()?;
-                client_builder = client_builder.use_preconfigured_tls(chaos_impersonate_settings);
+                client_builder = client_builder.impersonate_settings(chaos_impersonate_settings);
             }
             Some("random") => {
                 let impersonation = Impersonate::from_str(*get_random_element(IMPERSONATES))

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,7 +1,7 @@
 use crate::utils::{get_encoding_from_content, get_encoding_from_headers};
-use ahash::RandomState;
 use anyhow::{anyhow, Result};
 use encoding_rs::Encoding;
+use foldhash::fast::RandomState;
 use html2text::{
     from_read, from_read_with_decorator,
     render::{RichDecorator, TrivialDecorator},

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,61 @@
+use ahash::RandomState;
+use anyhow::{Error, Ok};
+use indexmap::IndexMap;
+
+use rquest::header::{HeaderMap, HeaderName, HeaderValue};
+
+pub trait HeadersTraits {
+    fn to_indexmap(&self) -> IndexMap<String, String, RandomState>;
+    fn to_headermap(&self) -> HeaderMap;
+    fn insert_key_value(&mut self, key: String, value: String) -> Result<(), Error>;
+}
+
+impl HeadersTraits for IndexMap<String, String, RandomState> {
+    fn to_indexmap(&self) -> IndexMap<String, String, RandomState> {
+        self.clone()
+    }
+    fn to_headermap(&self) -> HeaderMap {
+        self.iter()
+            .map(|(k, v)| {
+                (
+                    HeaderName::from_bytes(k.as_bytes())
+                        .unwrap_or_else(|k| panic!("Invalid header name: {k:?}")),
+                    HeaderValue::from_str(v)
+                        .unwrap_or_else(|v| panic!("Invalid header value: {v:?}")),
+                )
+            })
+            .collect()
+    }
+    fn insert_key_value(&mut self, key: String, value: String) -> Result<(), Error> {
+        self.insert(key.into(), value.into());
+        Ok(())
+    }
+}
+
+impl HeadersTraits for HeaderMap {
+    fn to_indexmap(&self) -> IndexMap<String, String, RandomState> {
+        self.iter()
+            .map(|(k, v)| {
+                (
+                    k.to_string(),
+                    v.to_str()
+                        .unwrap_or_else(|v| panic!("Invalid header value: {v:?}"))
+                        .to_string(),
+                )
+            })
+            .collect()
+    }
+
+    fn to_headermap(&self) -> HeaderMap {
+        self.clone()
+    }
+
+    fn insert_key_value(&mut self, key: String, value: String) -> Result<(), Error> {
+        let header_name = HeaderName::from_bytes(key.as_bytes())
+            .unwrap_or_else(|k| panic!("Invalid header name: {k:?}"));
+        let header_value = HeaderValue::from_bytes(value.as_bytes())
+            .unwrap_or_else(|k| panic!("Invalid header value: {k:?}"));
+        self.insert(header_name, header_value);
+        Ok(())
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,4 @@
-use ahash::RandomState;
+use foldhash::fast::RandomState;
 use anyhow::{Error, Ok};
 use indexmap::IndexMap;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use std::cmp::min;
 use std::sync::LazyLock;
 
-use ahash::RandomState;
+use foldhash::fast::RandomState;
 use indexmap::IndexMap;
 use rquest::boring::{
     error::ErrorStack,


### PR DESCRIPTION
1) Client: add [getter, setter] for `auth`, `auth_bearer`, `params`, `headers`, `proxy`, `timeout`
2) Client: add `https_only`, `http2_only` parameters; remove http1, http2
3) Bump rquest to v0.32
4) Add trait HeadersTraits
5) IndexMap: change ahash to foldhash
6) README: impersonates section - add `safari_18.2`