### PR TITLE
Add Response class to module so it can be imported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1079,6 +1079,7 @@ fn primp(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     pyo3_log::init();
 
     m.add_class::<Client>()?;
+    m.add_class::<Response>()?;
     m.add_function(wrap_pyfunction!(request, m)?)?;
     m.add_function(wrap_pyfunction!(get, m)?)?;
     m.add_function(wrap_pyfunction!(head, m)?)?;


### PR DESCRIPTION
For static type checking and other usage you can now stuff like:
```python
from primp import Response
```