### PR TITLE
fix(client): release GIL during builder + cache pyo3-log lookups

### DIFF
--- a/crates/primp-python/src/async/client.rs
+++ b/crates/primp-python/src/async/client.rs
@@ -56,6 +56,7 @@ impl AsyncClient {
         max_redirects=20, verify=true, ca_cert_file=None, https_only=false, http2_only=false,
         base_url=None, cookies=None))]
     fn new(
+        py: Python<'_>,
         auth: Option<(String, Option<String>)>,
         auth_bearer: Option<String>,
         params: Option<IndexMapSSR>,
@@ -77,40 +78,45 @@ impl AsyncClient {
         base_url: Option<String>,
         cookies: Option<IndexMapSSR>,
     ) -> PrimpResult<Self> {
-        let (client_builder, resolved_proxy) = configure_client_builder(
-            PrimpClient::builder(),
-            headers,
-            cookie_store,
-            referer,
-            proxy,
-            timeout,
-            connect_timeout,
-            read_timeout,
-            impersonate.as_deref(),
-            impersonate_os.as_deref(),
-            follow_redirects,
-            max_redirects,
-            verify,
-            ca_cert_file,
-            https_only,
-            http2_only,
-        )?;
+        // Release the GIL around the reqwest client build — identical
+        // reasoning to `Client::new`. See the comment there and
+        // vorner/pyo3-log#65 for the deadlock mechanism.
+        py.detach(|| {
+            let (client_builder, resolved_proxy) = configure_client_builder(
+                PrimpClient::builder(),
+                headers,
+                cookie_store,
+                referer,
+                proxy,
+                timeout,
+                connect_timeout,
+                read_timeout,
+                impersonate.as_deref(),
+                impersonate_os.as_deref(),
+                follow_redirects,
+                max_redirects,
+                verify,
+                ca_cert_file,
+                https_only,
+                http2_only,
+            )?;
 
-        let client = Arc::new(RwLock::new(client_builder.build()?));
+            let client = Arc::new(RwLock::new(client_builder.build()?));
 
-        Ok(AsyncClient {
-            client,
-            auth,
-            auth_bearer,
-            params,
-            proxy: resolved_proxy,
-            timeout,
-            connect_timeout,
-            read_timeout,
-            impersonate,
-            impersonate_os,
-            base_url,
-            cookies,
+            Ok(AsyncClient {
+                client,
+                auth,
+                auth_bearer,
+                params,
+                proxy: resolved_proxy,
+                timeout,
+                connect_timeout,
+                read_timeout,
+                impersonate,
+                impersonate_os,
+                base_url,
+                cookies,
+            })
         })
     }
 

--- a/crates/primp-python/src/lib.rs
+++ b/crates/primp-python/src/lib.rs
@@ -145,6 +145,7 @@ impl Client {
         max_redirects=20, verify=true, ca_cert_file=None, https_only=false, http2_only=false,
         base_url=None, cookies=None))]
     fn new(
+        py: Python<'_>,
         auth: Option<(String, Option<String>)>,
         auth_bearer: Option<String>,
         params: Option<IndexMapSSR>,
@@ -166,40 +167,55 @@ impl Client {
         base_url: Option<String>,
         cookies: Option<IndexMapSSR>,
     ) -> PrimpResult<Self> {
-        let (client_builder, resolved_proxy) = configure_client_builder(
-            PrimpClient::builder(),
-            headers,
-            cookie_store,
-            referer,
-            proxy,
-            timeout,
-            connect_timeout,
-            read_timeout,
-            impersonate.as_deref(),
-            impersonate_os.as_deref(),
-            follow_redirects,
-            max_redirects,
-            verify,
-            ca_cert_file,
-            https_only,
-            http2_only,
-        )?;
+        // Release the GIL while building the reqwest client. The build path
+        // runs TLS / root-CA / impersonation initialization which emits
+        // `log::*!` / `tracing::*!` callsites inside primp-reqwest, hyper,
+        // and rustls. Those forward through pyo3-log and need to acquire
+        // the GIL to call `logging.getLogger`. If we held the GIL here,
+        // concurrent threads constructing a Client would deadlock against
+        // Python's `logging._lock` / GIL ordering — classic pyo3-log
+        // pattern documented in vorner/pyo3-log#65, observed downstream in
+        // deedy5/ddgs#452, HKUDS/nanobot#2804, microsoft/amplifier#219.
+        //
+        // Everything inside `allow_threads` is pure Rust; no PyObject is
+        // touched, so releasing the GIL is safe and enforced at compile
+        // time (the closure is `Send`).
+        py.detach(|| {
+            let (client_builder, resolved_proxy) = configure_client_builder(
+                PrimpClient::builder(),
+                headers,
+                cookie_store,
+                referer,
+                proxy,
+                timeout,
+                connect_timeout,
+                read_timeout,
+                impersonate.as_deref(),
+                impersonate_os.as_deref(),
+                follow_redirects,
+                max_redirects,
+                verify,
+                ca_cert_file,
+                https_only,
+                http2_only,
+            )?;
 
-        let client = Arc::new(RwLock::new(client_builder.build()?));
+            let client = Arc::new(RwLock::new(client_builder.build()?));
 
-        Ok(Client {
-            client,
-            auth,
-            auth_bearer,
-            params,
-            proxy: resolved_proxy,
-            timeout,
-            connect_timeout,
-            read_timeout,
-            impersonate,
-            impersonate_os,
-            base_url,
-            cookies,
+            Ok(Client {
+                client,
+                auth,
+                auth_bearer,
+                params,
+                proxy: resolved_proxy,
+                timeout,
+                connect_timeout,
+                read_timeout,
+                impersonate,
+                impersonate_os,
+                base_url,
+                cookies,
+            })
         })
     }
 
@@ -862,6 +878,7 @@ fn get(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,
@@ -949,6 +966,7 @@ fn head(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,
@@ -1036,6 +1054,7 @@ fn options(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,
@@ -1123,6 +1142,7 @@ fn delete(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,
@@ -1210,6 +1230,7 @@ fn post(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,
@@ -1297,6 +1318,7 @@ fn put(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,
@@ -1384,6 +1406,7 @@ fn patch(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,
@@ -1473,6 +1496,7 @@ fn request(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,
@@ -1516,7 +1540,28 @@ fn request(
 
 #[pymodule]
 fn primp(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    pyo3_log::init();
+    // Install pyo3-log with per-target `(logger, level)` caching so
+    // tracing/log callsites inside primp (and its transitive deps reqwest /
+    // hyper / rustls) only call back into Python's logging module on the
+    // first emission per target. Subsequent emissions hit a Rust-side cache
+    // and never cross the GIL boundary.
+    //
+    // This complements — but does not replace — the `py.detach` fix
+    // applied to `Client::new` and `AsyncClient::new`. The `allow_threads`
+    // release is what actually prevents the first-call race from deadlocking
+    // against `logging._lock`; caching here is documented pyo3-log best
+    // practice and keeps steady-state hot paths GIL-free for logging.
+    match pyo3_log::Logger::new(_py, pyo3_log::Caching::LoggersAndLevels) {
+        Ok(logger) => {
+            let _ = logger.install();
+        }
+        Err(_) => {
+            // Fall back to the uncached default if LoggersAndLevels is
+            // unavailable for some reason; allow_threads still keeps us
+            // deadlock-free.
+            pyo3_log::init();
+        }
+    }
 
     // Re-export exception types from error module - new hierarchy
     use error::{

--- a/crates/primp-python/tests/test_parallel_client.py
+++ b/crates/primp-python/tests/test_parallel_client.py
@@ -1,0 +1,47 @@
+"""Regression test for a first-call deadlock on parallel Client construction.
+
+Several threads concurrently constructing ``primp.Client(impersonate="random")``
+used to deadlock: each construction runs TLS / root-CA / impersonation setup
+in Rust, and the log/tracing callsites inside reqwest + hyper + rustls
+forward through ``pyo3-log`` back into Python's ``logging.getLogger``. With
+every thread holding the GIL across the whole builder, those re-entries
+serialized against Python's ``logging._lock`` and the GIL in a way that
+stalled indefinitely (faulthandler showed workers parked inside
+``logging/__init__.py:getLogger`` while inside ``primp.Client()``).
+
+The fix releases the GIL across the reqwest build (``py.detach``) in
+``Client::new`` / ``AsyncClient::new``, which is the pattern documented in
+vorner/pyo3-log#65. This test locks in that behaviour.
+"""
+import threading
+
+import primp
+
+
+def test_parallel_client_new_does_not_deadlock():
+    num_threads = 8
+    barrier = threading.Barrier(num_threads)
+    results: list[str] = []
+    results_lock = threading.Lock()
+
+    def worker() -> None:
+        barrier.wait()
+        try:
+            primp.Client(impersonate="random", impersonate_os="random", timeout=5)
+            status = "ok"
+        except Exception as exc:  # pragma: no cover - diagnostic only
+            status = f"err:{exc!r}"
+        with results_lock:
+            results.append(status)
+
+    threads = [
+        threading.Thread(target=worker, name=f"W{i}") for i in range(num_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=20)
+
+    stuck = [t.name for t in threads if t.is_alive()]
+    assert not stuck, f"deadlock: threads still alive after 20s: {stuck}"
+    assert results == ["ok"] * num_threads, results


### PR DESCRIPTION
## Summary

Fixes a first-call deadlock that occurs when multiple threads construct `primp.Client(impersonate="random", …)` concurrently — the typical pattern for `asyncio.gather(asyncio.to_thread(primp.Client, …))` in FastAPI / agent / scraping workloads.

## Reproduction

```python
import threading, primp
barrier = threading.Barrier(8)

def worker():
    barrier.wait()
    primp.Client(impersonate="random", impersonate_os="random", timeout=5)

threads = [threading.Thread(target=worker) for _ in range(8)]
for t in threads: t.start()
for t in threads: t.join(timeout=20)  # never returns on primp 1.2.2
```

Before this change: hangs for the full 20 s (and indefinitely in real workloads).
After: completes in ~10 ms on my machine.

## faulthandler fingerprint

```
Thread W*:
  File ".../primp_repro.py" in worker
  -> primp.Client(impersonate="random", ...)
     -> logging/__init__.py:2130 in getLogger   ← stuck
```

## Root cause

Walking back from the stuck stack: `Client::new()` runs the reqwest builder (TLS / root-CA / impersonation setup) **while holding the GIL**. That builder path fires `log::warn!` / `tracing::*!` call-sites inside `primp-reqwest`, `hyper`, `rustls` — notably `log::warn!("failed to load native root certificate: …")` in `primp-reqwest/src/tls.rs:633`. Every log call forwards through `pyo3-log` back into Python's `logging.getLogger(target).isEnabledFor(level)`.

With several threads all trying to do this under the GIL, they race on Python's `logging._lock` inside `Manager.getLogger` in a way that does not recover. `requests`/primp inter-byte `timeout` semantics cannot break it, and `asyncio.to_thread` / `run_in_executor` cannot cancel OS threads — so from the outside, the process looks permanently stalled.

This matches the pattern documented by the pyo3-log maintainer in **vorner/pyo3-log#65** ("PyO3 method holding the GIL while something else tries to log from Rust → deadlock"), and reproduces identically with just `primp` — no `ddgs` involved.

`Client::request()` already does the right thing with `py.detach(|| RUNTIME.block_on(future))` at lib.rs:491. `Client::new()` and `AsyncClient::new()` were missing the corresponding release.

## Fix

Two parts, both in `crates/primp-python/`:

1. Wrap the reqwest build path in `py.detach(|| …)` for both `Client::new` and `AsyncClient::new`. Everything inside the closure is pure Rust (no `PyObject` is touched), so releasing the GIL is safe and enforced at compile time (the closure is `Send`). `pyo3-log` callbacks from reqwest / hyper / rustls now acquire the GIL cleanly when they fire. **This is the root-cause fix.**

2. Install `pyo3-log` with `Caching::LoggersAndLevels` in the `#[pymodule]` init. After the first emission per target, subsequent emissions hit a Rust-side cache and never cross the GIL. Documented pyo3-log best-practice; complements (1) by keeping steady-state hot paths GIL-free for logging.

The **Python-level API is unchanged**: `py: Python<'_>` on the constructors is PyO3-internal, the `.pyi` stub stays identical, and the module-level convenience functions (`get` / `head` / `post` / …) forward `py` to `Client::new` so they automatically benefit from the fix.

## Verification

- **New regression test** `crates/primp-python/tests/test_parallel_client.py`: 8 threads constructing `Client(impersonate="random")` concurrently. Before: hangs for 20 s timeout. After: passes in 0.03 s.
- **Existing pytest suite**: 354/354 pass (`pytest tests/`).
- **End-to-end downstream**: running `ddgs 9.13.0` against this patched `primp` with the 4-way concurrent `asyncio.gather` search pattern from the linked consumer reports completes in ~2.8 s instead of hanging, and the asyncio event loop stays responsive throughout.

## Downstream reports this unblocks

- [deedy5/ddgs#452](https://github.com/deedy5/ddgs/pull/452) — consumer-side `threading.Lock` around `primp.Client(...)` construction. Becomes obsolete once this lands.
- [HKUDS/nanobot#2804](https://github.com/HKUDS/nanobot/issues/2804) / [#2805](https://github.com/HKUDS/nanobot/pull/2805) — consumer-side `asyncio.wait_for` wrap. Still useful as defense-in-depth, but the underlying hang disappears.
- [microsoft/amplifier#219](https://github.com/microsoft/amplifier/issues/219) — open, exact same symptom.
- Root-cause pattern: [vorner/pyo3-log#65](https://github.com/vorner/pyo3-log/issues/65).

Happy to iterate on naming, comment style, or split the two hunks into separate commits if preferred.