### PR TITLE
fix(primp-python): resolve parallel client initialization deadlock

### DIFF
--- a/crates/primp-h2/src/proto/streams/stream.rs
+++ b/crates/primp-h2/src/proto/streams/stream.rs
@@ -341,10 +341,8 @@ impl Stream {
                 Some(val) => *rem = val,
                 None => return Err(()),
             },
-            ContentLength::Head => {
-                if len != 0 {
-                    return Err(());
-                }
+            ContentLength::Head if len != 0 => {
+                return Err(());
             }
             _ => {}
         }

--- a/crates/primp-hyper/src/proto/h1/conn.rs
+++ b/crates/primp-hyper/src/proto/h1/conn.rs
@@ -665,11 +665,9 @@ where
                 Version::HTTP_10 => self.state.disable_keep_alive(),
                 // If response is version 1.1 and keep-alive is wanted, add
                 // Connection: keep-alive header when not present
-                Version::HTTP_11 => {
-                    if self.state.wants_keep_alive() {
-                        head.headers
-                            .insert(CONNECTION, HeaderValue::from_static("keep-alive"));
-                    }
+                Version::HTTP_11 if self.state.wants_keep_alive() => {
+                    head.headers
+                        .insert(CONNECTION, HeaderValue::from_static("keep-alive"));
                 }
                 _ => (),
             }

--- a/crates/primp-python/src/async/client.rs
+++ b/crates/primp-python/src/async/client.rs
@@ -56,6 +56,7 @@ impl AsyncClient {
         max_redirects=20, verify=true, ca_cert_file=None, https_only=false, http2_only=false,
         base_url=None, cookies=None))]
     fn new(
+        py: Python<'_>,
         auth: Option<(String, Option<String>)>,
         auth_bearer: Option<String>,
         params: Option<IndexMapSSR>,
@@ -77,26 +78,29 @@ impl AsyncClient {
         base_url: Option<String>,
         cookies: Option<IndexMapSSR>,
     ) -> PrimpResult<Self> {
-        let (client_builder, resolved_proxy) = configure_client_builder(
-            PrimpClient::builder(),
-            headers,
-            cookie_store,
-            referer,
-            proxy,
-            timeout,
-            connect_timeout,
-            read_timeout,
-            impersonate.as_deref(),
-            impersonate_os.as_deref(),
-            follow_redirects,
-            max_redirects,
-            verify,
-            ca_cert_file,
-            https_only,
-            http2_only,
-        )?;
+        let (resolved_proxy, client) = py.detach(|| -> PrimpResult<_> {
+            let (client_builder, resolved_proxy) = configure_client_builder(
+                PrimpClient::builder(),
+                headers,
+                cookie_store,
+                referer,
+                proxy,
+                timeout,
+                connect_timeout,
+                read_timeout,
+                impersonate.as_deref(),
+                impersonate_os.as_deref(),
+                follow_redirects,
+                max_redirects,
+                verify,
+                ca_cert_file,
+                https_only,
+                http2_only,
+            )?;
 
-        let client = Arc::new(RwLock::new(client_builder.build()?));
+            let client = Arc::new(RwLock::new(client_builder.build()?));
+            Ok((resolved_proxy, client))
+        })?;
 
         Ok(AsyncClient {
             client,

--- a/crates/primp-python/src/async/response.rs
+++ b/crates/primp-python/src/async/response.rs
@@ -20,7 +20,6 @@ use crate::client_builder::IndexMapSSR;
 use crate::error::{body_collection_error, convert_reqwest_error, BodyError, PrimpErrorEnum};
 use crate::traits::HeadersTraits;
 use crate::utils::extract_encoding;
-use crate::RUNTIME;
 
 /// Collect body bytes from a response using a pre-allocated buffer.
 /// Uses `Vec::with_capacity(8 * 1024)` for efficient buffer allocation.
@@ -102,8 +101,9 @@ impl AsyncResponse {
         }
 
         let resp = Arc::clone(&self.resp);
+        let runtime = crate::get_runtime(py);
         let bytes: Bytes = py.detach(|| {
-            RUNTIME.block_on(async {
+            runtime.block_on(async {
                 let mut resp_guard = resp.lock().await;
                 match resp_guard.as_mut() {
                     Some(r) => collect_body_bytes(r).await,
@@ -124,20 +124,25 @@ impl AsyncResponse {
 
     /// Get character encoding (sync)
     #[getter]
-    fn get_encoding(&mut self, _py: Python<'_>) -> PyResult<String> {
+    fn get_encoding(&mut self, py: Python<'_>) -> PyResult<String> {
         if let Some(encoding) = self._encoding.as_ref() {
             return Ok(encoding.clone());
         }
 
         let resp = Arc::clone(&self.resp);
-        let encoding = RUNTIME.block_on(async {
-            let resp_guard = resp.lock().await;
-            match resp_guard.as_ref() {
-                Some(r) => Ok::<String, PyErr>(extract_encoding(r.headers()).name().to_string()),
-                None => Err(BodyError::new_err(
-                    "Response body already consumed or moved",
-                )),
-            }
+        let runtime = crate::get_runtime(py);
+        let encoding = py.detach(|| {
+            runtime.block_on(async {
+                let resp_guard = resp.lock().await;
+                match resp_guard.as_ref() {
+                    Some(r) => {
+                        Ok::<String, PyErr>(extract_encoding(r.headers()).name().to_string())
+                    }
+                    None => Err(BodyError::new_err(
+                        "Response body already consumed or moved",
+                    )),
+                }
+            })
         })?;
 
         self._encoding = Some(encoding.clone());
@@ -172,7 +177,8 @@ impl AsyncResponse {
         }
 
         let resp = Arc::clone(&self.resp);
-        let headers: IndexMapSSR = RUNTIME.block_on(async {
+        let runtime = crate::get_runtime(py);
+        let headers: IndexMapSSR = runtime.block_on(async {
             let resp_guard = resp.lock().await;
             match resp_guard.as_ref() {
                 Some(r) => Ok(r.headers().to_indexmap()),
@@ -195,7 +201,8 @@ impl AsyncResponse {
         }
 
         let resp = Arc::clone(&self.resp);
-        let cookies: IndexMapSSR = RUNTIME.block_on(async {
+        let runtime = crate::get_runtime(py);
+        let cookies: IndexMapSSR = runtime.block_on(async {
             let resp_guard = resp.lock().await;
             match resp_guard.as_ref() {
                 Some(r) => Ok(crate::extract_cookies_to_indexmap(r.headers())),

--- a/crates/primp-python/src/lib.rs
+++ b/crates/primp-python/src/lib.rs
@@ -1,11 +1,12 @@
 #![allow(clippy::too_many_arguments)]
-use std::sync::{Arc, LazyLock, RwLock};
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use ::primp::{
     multipart, Body, Client as PrimpClient, Method, Proxy, Response as PrimpResponse, Url,
 };
 use pyo3::prelude::*;
+use pyo3::sync::PyOnceLock;
 use pythonize::depythonize;
 use serde_json::Value;
 use tokio::{
@@ -36,12 +37,18 @@ mod utils;
 use utils::extract_encoding;
 
 // Tokio global one-thread runtime
-static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
-    runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("Failed to create Tokio runtime")
-});
+static RUNTIME: PyOnceLock<Runtime> = PyOnceLock::new();
+
+/// Get the global Tokio runtime, initializing it if necessary.
+#[inline(always)]
+pub(crate) fn get_runtime(py: Python<'_>) -> &Runtime {
+    RUNTIME.get_or_init(py, || {
+        runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create Tokio runtime")
+    })
+}
 
 #[pyclass(subclass)]
 /// HTTP client that can impersonate web browsers.
@@ -145,6 +152,7 @@ impl Client {
         max_redirects=20, verify=true, ca_cert_file=None, https_only=false, http2_only=false,
         base_url=None, cookies=None))]
     fn new(
+        py: Python<'_>,
         auth: Option<(String, Option<String>)>,
         auth_bearer: Option<String>,
         params: Option<IndexMapSSR>,
@@ -166,26 +174,29 @@ impl Client {
         base_url: Option<String>,
         cookies: Option<IndexMapSSR>,
     ) -> PrimpResult<Self> {
-        let (client_builder, resolved_proxy) = configure_client_builder(
-            PrimpClient::builder(),
-            headers,
-            cookie_store,
-            referer,
-            proxy,
-            timeout,
-            connect_timeout,
-            read_timeout,
-            impersonate.as_deref(),
-            impersonate_os.as_deref(),
-            follow_redirects,
-            max_redirects,
-            verify,
-            ca_cert_file,
-            https_only,
-            http2_only,
-        )?;
+        let (resolved_proxy, client) = py.detach(|| -> PrimpResult<_> {
+            let (client_builder, resolved_proxy) = configure_client_builder(
+                PrimpClient::builder(),
+                headers,
+                cookie_store,
+                referer,
+                proxy,
+                timeout,
+                connect_timeout,
+                read_timeout,
+                impersonate.as_deref(),
+                impersonate_os.as_deref(),
+                follow_redirects,
+                max_redirects,
+                verify,
+                ca_cert_file,
+                https_only,
+                http2_only,
+            )?;
 
-        let client = Arc::new(RwLock::new(client_builder.build()?));
+            let client = Arc::new(RwLock::new(client_builder.build()?));
+            Ok((resolved_proxy, client))
+        })?;
 
         Ok(Client {
             client,
@@ -487,8 +498,9 @@ impl Client {
 
         // Execute an async future, releasing the Python GIL for concurrency.
         // Use Tokio global runtime to block on the future.
+        let runtime = get_runtime(py);
         let response: Result<(PrimpResponse, String, u16), PrimpErrorEnum> =
-            py.detach(|| RUNTIME.block_on(future));
+            py.detach(move || runtime.block_on(future));
 
         // Restore redirect policy if it was changed
         if follow_redirects.is_some() {
@@ -862,6 +874,7 @@ fn get(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,
@@ -949,6 +962,7 @@ fn head(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,
@@ -1036,6 +1050,7 @@ fn options(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,
@@ -1123,6 +1138,7 @@ fn delete(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,
@@ -1210,6 +1226,7 @@ fn post(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,
@@ -1297,6 +1314,7 @@ fn put(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,
@@ -1384,6 +1402,7 @@ fn patch(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,
@@ -1473,6 +1492,7 @@ fn request(
     stream: bool,
 ) -> PyResult<Py<PyAny>> {
     let client = Client::new(
+        py,
         None,
         None,
         None,

--- a/crates/primp-python/src/response.rs
+++ b/crates/primp-python/src/response.rs
@@ -20,7 +20,6 @@ use crate::client_builder::IndexMapSSR;
 use crate::error::{body_collection_error, convert_reqwest_error, BodyError, PrimpErrorEnum};
 use crate::traits::HeadersTraits;
 use crate::utils::extract_encoding;
-use crate::RUNTIME;
 
 /// Collect body bytes from a response using a pre-allocated buffer.
 /// Uses `Vec::with_capacity(8 * 1024)` for efficient buffer allocation.
@@ -131,7 +130,8 @@ impl Response {
             }
         }
 
-        let bytes: Bytes = py.detach(|| RUNTIME.block_on(self.read_bytes()))?;
+        let runtime = crate::get_runtime(py);
+        let bytes: Bytes = py.detach(|| runtime.block_on(self.read_bytes()))?;
         let content = PyBytes::new(py, &bytes);
 
         if !self.streaming {
@@ -147,8 +147,9 @@ impl Response {
         }
 
         let resp = Arc::clone(&self.resp);
+        let runtime = crate::get_runtime(py);
         let encoding = py.detach(|| {
-            RUNTIME.block_on(async {
+            runtime.block_on(async {
                 let resp_guard = resp.lock().await;
                 match resp_guard.as_ref() {
                     Some(r) => Ok(extract_encoding(r.headers()).name().to_string()),
@@ -206,8 +207,9 @@ impl Response {
         }
 
         let resp = Arc::clone(&self.resp);
+        let runtime = crate::get_runtime(py);
         let new_headers = py.detach(|| {
-            RUNTIME.block_on(async {
+            runtime.block_on(async {
                 let resp_guard = resp.lock().await;
                 match resp_guard.as_ref() {
                     Some(r) => Ok(r.headers().to_indexmap()),
@@ -230,8 +232,9 @@ impl Response {
         }
 
         let resp = Arc::clone(&self.resp);
+        let runtime = crate::get_runtime(py);
         let cookie_map = py.detach(|| {
-            RUNTIME.block_on(async {
+            runtime.block_on(async {
                 let resp_guard = resp.lock().await;
                 match resp_guard.as_ref() {
                     Some(r) => Ok(crate::extract_cookies_to_indexmap(r.headers())),
@@ -330,7 +333,8 @@ impl Response {
     }
 
     fn next<'rs>(&mut self, py: Python<'rs>) -> PyResult<Option<Bound<'rs, PyBytes>>> {
-        let chunk = py.detach(|| RUNTIME.block_on(self.next_chunk()))?;
+        let runtime = crate::get_runtime(py);
+        let chunk = py.detach(|| runtime.block_on(self.next_chunk()))?;
         match chunk {
             Some(data) => Ok(Some(PyBytes::new(py, &data))),
             None => Ok(None),
@@ -339,8 +343,9 @@ impl Response {
 
     fn close(&mut self, py: Python<'_>) -> PyResult<()> {
         let resp = Arc::clone(&self.resp);
+        let runtime = crate::get_runtime(py);
         py.detach(|| {
-            RUNTIME.block_on(async {
+            runtime.block_on(async {
                 let mut resp_guard = resp.lock().await;
                 resp_guard.take();
             })
@@ -395,8 +400,9 @@ impl BytesIterator {
         }
 
         let resp = Arc::clone(&self.resp);
+        let runtime = crate::get_runtime(py);
         let chunk = py.detach(|| {
-            RUNTIME.block_on(async {
+            runtime.block_on(async {
                 let mut resp_guard = resp.lock().await;
                 match resp_guard.as_mut() {
                     Some(r) => match r.chunk().await {
@@ -475,8 +481,9 @@ impl TextIterator {
         }
 
         let resp = Arc::clone(&self.resp);
+        let runtime = crate::get_runtime(py);
         let chunk = py.detach(|| {
-            RUNTIME.block_on(async {
+            runtime.block_on(async {
                 let mut resp_guard = resp.lock().await;
                 match resp_guard.as_mut() {
                     Some(r) => match r.chunk().await {
@@ -565,8 +572,9 @@ impl LinesIterator {
             }
 
             let resp = Arc::clone(&self.resp);
+            let runtime = crate::get_runtime(py);
             let chunk = py.detach(|| {
-                RUNTIME.block_on(async {
+                runtime.block_on(async {
                     let mut resp_guard = resp.lock().await;
                     match resp_guard.as_mut() {
                         Some(r) => match r.chunk().await {

--- a/crates/primp-python/tests/test_parallel_client.py
+++ b/crates/primp-python/tests/test_parallel_client.py
@@ -1,0 +1,58 @@
+"""Regression test for a first-call deadlock on parallel Client construction."""
+
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import asyncio
+
+import primp
+
+
+class AsyncBarrier:
+    """Simple async barrier implementation for Python <3.11 compatibility."""
+    def __init__(self, parties):
+        self.parties = parties
+        self._count = 0
+        self._event = asyncio.Event()
+        self._lock = asyncio.Lock()
+
+    async def wait(self):
+        async with self._lock:
+            self._count += 1
+            if self._count == self.parties:
+                self._event.set()
+        await self._event.wait()
+
+
+def test_parallel_client_new_does_not_deadlock():
+    num_threads = 8
+    barrier = threading.Barrier(num_threads)
+
+    def worker() -> str:
+        barrier.wait()
+        try:
+            primp.Client(impersonate="random", impersonate_os="random", timeout=5)
+            return "ok"
+        except Exception as exc:
+            return f"err:{exc!r}"
+
+    with ThreadPoolExecutor(max_workers=num_threads) as executor:
+        futures = [executor.submit(worker) for _ in range(num_threads)]
+        results = [f.result(timeout=20) for f in futures]
+
+    assert results == ["ok"] * num_threads, results
+
+
+async def test_parallel_asyncclient_new_does_not_deadlock():
+    num_tasks = 8
+    barrier = AsyncBarrier(num_tasks)
+
+    async def worker() -> str:
+        await barrier.wait()
+        try:
+            primp.AsyncClient(impersonate="random", impersonate_os="random", timeout=5)
+            return "ok"
+        except Exception as exc:
+            return f"err:{exc!r}"
+
+    results = await asyncio.gather(*[worker() for _ in range(num_tasks)])
+    assert results == ["ok"] * num_tasks, results

--- a/crates/primp-rustls/rustls/src/client/hs.rs
+++ b/crates/primp-rustls/rustls/src/client/hs.rs
@@ -1428,13 +1428,13 @@ impl ExpectServerHelloOrHelloRetryRequest {
 
         // If we offered ECH, we need to confirm that the server accepted it.
         match (self.next.ech_state.as_ref(), cs.tls13()) {
-            (Some(ech_state), Some(tls13_cs)) => {
-                if !ech_state.confirm_hrr_acceptance(hrr, tls13_cs, cx.common)? {
-                    // If the server did not confirm, then note the new ECH status but
-                    // continue the handshake. We will abort with an ECH required error
-                    // at the end.
-                    cx.data.ech_status = EchStatus::Rejected;
-                }
+            (Some(ech_state), Some(tls13_cs))
+                if !ech_state.confirm_hrr_acceptance(hrr, tls13_cs, cx.common)? =>
+            {
+                // If the server did not confirm, then note the new ECH status but
+                // continue the handshake. We will abort with an ECH required error
+                // at the end.
+                cx.data.ech_status = EchStatus::Rejected;
             }
             (Some(_), None) => {
                 unreachable!("ECH state should only be set when TLS 1.3 was negotiated")


### PR DESCRIPTION
Replace global std LazyLock with PyOnceLock for Tokio runtime initialization that correctly respects Python GIL semantics. Release GIL during client builder execution to prevent deadlock between std OnceLock initialization and background thread GIL acquisition when constructing clients from multiple threads.

Add parallel client construction regression test covering both sync and async client implementations.